### PR TITLE
Add Support for Netflow v9

### DIFF
--- a/converter/input/mgologstash/flow_test.go
+++ b/converter/input/mgologstash/flow_test.go
@@ -96,7 +96,7 @@ func TestInheritance(t *testing.T) {
 	require.True(t, ok)
 }
 
-func TestFillFromIPFIXBSONMapNATTranslation(t *testing.T) {
+func TestFillFromIPFIXBSONmAP(t *testing.T) {
 	var flow1 = new(mgologstash.Flow)
 	var testData1 = bson.M{
 		"_id":  bson.ObjectId("5b72d69af6a43336c6004e07"),
@@ -122,8 +122,22 @@ func TestFillFromIPFIXBSONMapNATTranslation(t *testing.T) {
 
 	var error1 = flow1.FillFromBSONMap(testData1)
 	require.Nil(t, error1)
-	require.Equal(t, flow1.DestinationIPAddress(), "5.5.5.5")
-	require.Equal(t, flow1.DestinationPort(), uint16(55))
+
+	require.Equal(t, testData1["_id"], flow1.ID)
+	require.Equal(t, testData1["host"], flow1.Exporter())
+
+	ipfixMap1 := (testData1["netflow"].(bson.M))
+	require.Equal(t, ipfixMap1["sourceIPv4Address"], flow1.SourceIPAddress())
+	require.Equal(t, ipfixMap1["postNATDestinationIPv4Address"], flow1.DestinationIPAddress())
+	require.Equal(t, uint8(ipfixMap1["version"].(int)), flow1.Version())
+	require.Equal(t, int64(ipfixMap1["packetTotalCount"].(int64)), flow1.PacketTotalCount())
+	require.Equal(t, int64(ipfixMap1["octetTotalCount"].(int64)), flow1.OctetTotalCount())
+	require.Equal(t, uint16(ipfixMap1["sourceTransportPort"].(int)), flow1.SourcePort())
+	require.Equal(t, ipfixMap1["flowStartMilliseconds"], flow1.Netflow.FlowStartMilliseconds)
+	require.Equal(t, protocols.Identifier(ipfixMap1["protocolIdentifier"].(int)), flow1.ProtocolIdentifier())
+	require.Equal(t, uint16(ipfixMap1["postNAPTDestinationTransportPort"].(int)), flow1.DestinationPort())
+	require.Equal(t, ipfixMap1["flowEndMilliseconds"], flow1.Netflow.FlowEndMilliseconds)
+	require.Equal(t, input.FlowEndReason(ipfixMap1["flowEndReason"].(int)), flow1.FlowEndReason())
 
 	var flow2 = new(mgologstash.Flow)
 	var testData2 = bson.M{
@@ -148,8 +162,8 @@ func TestFillFromIPFIXBSONMapNATTranslation(t *testing.T) {
 
 	var error2 = flow2.FillFromBSONMap(testData2)
 	require.Nil(t, error2)
-	require.Equal(t, flow2.DestinationIPAddress(), "2001:db8:85a3:8d3:1319:8a2e:370:7348")
-	require.Equal(t, flow2.DestinationPort(), uint16(57))
+	require.Equal(t, "2001:db8:85a3:8d3:1319:8a2e:370:7348", flow2.DestinationIPAddress())
+	require.Equal(t, uint16(57), flow2.DestinationPort())
 }
 
 func TestFillFromNetflowv9BSONMapIPv4(t *testing.T) {
@@ -199,4 +213,38 @@ func TestFillFromNetflowv9BSONMapIPv4(t *testing.T) {
 	require.Equal(t, netflowMap["last_switched"], flow.Netflow.FlowEndMilliseconds)
 	//assume end of flow since we don't have the data
 	require.Equal(t, input.EndOfFlow, flow.FlowEndReason())
+
+	flow2 := &mgologstash.Flow{}
+	inputMap2 := bson.M{
+		"_id":        bson.ObjectId("5b6b4e2e10a0cf244f0180aa"),
+		"@timestamp": "\"2018-08-08T20:10:20.000Z\"",
+		"host":       "73.149.157.171",
+		"netflow": bson.M{
+			"output_snmp":         1,
+			"ipv6_src_addr":       "2002:db8:85a3:8d3:1319:8a2e:370:7345",
+			"xlate_src_addr_ipv6": "2002:db8:85a3:8d3:1319:8a2e:370:7346",
+			"ipv6_dst_addr":       "2002:db8:85a3:8d3:1319:8a2e:370:7347",
+			"xlate_dst_addr_ipv6": "2001:db8:85a3:8d3:1319:8a2e:370:7348",
+			"input_snmp":          1,
+			"ipv4_next_hop":       "0.0.0.0",
+			"version":             9,
+			"flow_seq_num":        192,
+			"flowset_id":          256,
+			"in_pkts":             2,
+			"in_bytes":            603,
+			"l4_src_port":         47608,
+			"first_switched":      "2018-08-08T20:10:21.000Z",
+			"xlate_src_port":      47608,
+			"protocol":            6,
+			"xlate_dst_port":      444,
+			"l4_dst_port":         443,
+			"last_switched":       "2018-08-08T20:10:21.000Z",
+		},
+		"@version": "1",
+	}
+
+	var error2 = flow2.FillFromBSONMap(inputMap2)
+	require.Nil(t, error2)
+	require.Equal(t, "2001:db8:85a3:8d3:1319:8a2e:370:7348", flow2.DestinationIPAddress())
+	require.Equal(t, uint16(444), flow2.DestinationPort())
 }

--- a/converter/input/mgologstash/flow_test.go
+++ b/converter/input/mgologstash/flow_test.go
@@ -96,57 +96,57 @@ func TestInheritance(t *testing.T) {
 	require.True(t, ok)
 }
 
-func TestFillFromBSONMap(t *testing.T){
+func TestFillFromBSONMap(t *testing.T) {
 	var flow1 = new(mgologstash.Flow)
 	var testData1 = bson.M{
-		"_id": bson.ObjectId("5b72d69af6a43336c6004e07"),
+		"_id":  bson.ObjectId("5b72d69af6a43336c6004e07"),
 		"host": "A",
-		"netflow": bson.M {
-		"sourceIPv4Address": "1.1.1.1",
-		"sourceTransportPort" : 24846,
-		"destinationIPv4Address" : "2.2.2.2",
-		"destinationIPv6Address" : "2002:db8:85a3:8d3:1319:8a2e:370:7348",
-		"destinationTransportPort" : 53,
-		"flowStartMilliseconds" : "2018-05-04T22:36:40.766Z",
-		"flowEndMilliseconds" : "2018-05-04T22:36:40.960Z",
-		"octetTotalCount" : int64(math.MaxUint32 + 1),
-		"packetTotalCount" : int64(math.MaxUint32 + 1),
-		"protocolIdentifier" : int(protocols.UDP),
-		"flowEndReason" : int(input.ActiveTimeout),
-		"version" : 5,
-		"postNATDestinationIPv4Address" : "5.5.5.5",
-		"postNAPTDestinationTransportPort" : 55,
-		"postNATDestinationIPv6Address" : "2001:db8:85a3:8d3:1319:8a2e:370:7348",
+		"netflow": bson.M{
+			"sourceIPv4Address":                "1.1.1.1",
+			"sourceTransportPort":              24846,
+			"destinationIPv4Address":           "2.2.2.2",
+			"destinationIPv6Address":           "2002:db8:85a3:8d3:1319:8a2e:370:7348",
+			"destinationTransportPort":         53,
+			"flowStartMilliseconds":            "2018-05-04T22:36:40.766Z",
+			"flowEndMilliseconds":              "2018-05-04T22:36:40.960Z",
+			"octetTotalCount":                  int64(math.MaxUint32 + 1),
+			"packetTotalCount":                 int64(math.MaxUint32 + 1),
+			"protocolIdentifier":               int(protocols.UDP),
+			"flowEndReason":                    int(input.ActiveTimeout),
+			"version":                          10,
+			"postNATDestinationIPv4Address":    "5.5.5.5",
+			"postNAPTDestinationTransportPort": 55,
+			"postNATDestinationIPv6Address":    "2001:db8:85a3:8d3:1319:8a2e:370:7348",
 		},
 	}
 
-	var error1 = flow1.FillFromBSONMap(testData1);
+	var error1 = flow1.FillFromBSONMap(testData1)
 	require.Nil(t, error1)
 	require.Equal(t, flow1.DestinationIPAddress(), "5.5.5.5")
 	require.Equal(t, flow1.DestinationPort(), uint16(55))
 
 	var flow2 = new(mgologstash.Flow)
 	var testData2 = bson.M{
-		"_id": bson.ObjectId("5b72d69af6a43336c6004e07"),
+		"_id":  bson.ObjectId("5b72d69af6a43336c6004e07"),
 		"host": "A",
-		"netflow": bson.M {
-		"sourceIPv4Address": "1.1.1.1",
-		"sourceTransportPort" : 24846,
-		"destinationIPv6Address" : "2002:db8:85a3:8d3:1319:8a2e:370:7348",
-		"destinationTransportPort" : 53,
-		"flowStartMilliseconds" : "2018-05-04T22:36:40.766Z",
-		"flowEndMilliseconds" : "2018-05-04T22:36:40.960Z",
-		"octetTotalCount" : int64(math.MaxUint32 + 1),
-		"packetTotalCount" : int64(math.MaxUint32 + 1),
-		"protocolIdentifier" : int(protocols.UDP),
-		"flowEndReason" : int(input.ActiveTimeout),
-		"version" : 5,
-		"postNAPTDestinationTransportPort" : 57,
-		"postNATDestinationIPv6Address" : "2001:db8:85a3:8d3:1319:8a2e:370:7348",
+		"netflow": bson.M{
+			"sourceIPv4Address":                "1.1.1.1",
+			"sourceTransportPort":              24846,
+			"destinationIPv6Address":           "2002:db8:85a3:8d3:1319:8a2e:370:7348",
+			"destinationTransportPort":         53,
+			"flowStartMilliseconds":            "2018-05-04T22:36:40.766Z",
+			"flowEndMilliseconds":              "2018-05-04T22:36:40.960Z",
+			"octetTotalCount":                  int64(math.MaxUint32 + 1),
+			"packetTotalCount":                 int64(math.MaxUint32 + 1),
+			"protocolIdentifier":               int(protocols.UDP),
+			"flowEndReason":                    int(input.ActiveTimeout),
+			"version":                          10,
+			"postNAPTDestinationTransportPort": 57,
+			"postNATDestinationIPv6Address":    "2001:db8:85a3:8d3:1319:8a2e:370:7348",
 		},
 	}
 
-	var error2 = flow2.FillFromBSONMap(testData2);
+	var error2 = flow2.FillFromBSONMap(testData2)
 	require.Nil(t, error2)
 	require.Equal(t, flow2.DestinationIPAddress(), "2001:db8:85a3:8d3:1319:8a2e:370:7348")
 	require.Equal(t, flow2.DestinationPort(), uint16(57))


### PR DESCRIPTION
This PR adds support for Netflow v9 records. Additionally it supports Netflow v9 NAT. 

This PR separates the parsing of the inner Netflow record from the outer logstash details in mgologstash.Flow. This will likely cause conflicts with concurrent work on the IPFIX parser.

A test has been included for parsing netflow v9 records. This test could be used as an example for testing IPFIX records. 