### PR TITLE
Allow delta counts for octets and packets in IPFIX

### DIFF
--- a/converter/input/mgologstash/flow.go
+++ b/converter/input/mgologstash/flow.go
@@ -169,7 +169,11 @@ func (i *Flow) FillFromBSONMap(inputMap bson.M) error {
 
 	octetTotalIface, ok := netflowMap["octetTotalCount"]
 	if !ok {
-		return errors.New("input map must contain key 'netflow.octetTotalCount'")
+		//delta counts CAN be total counts by RFC definition >.<"
+		octetTotalIface, ok = netflowMap["octetDeltaCount"]
+		if !ok {
+			return errors.New("input map must contain key 'netflow.octetTotalCount' or 'netflow.octetDeltaCount'")
+		}
 	}
 	//fmt.Println("23")
 	octetTotal, ok := octetTotalIface.(int64)
@@ -186,7 +190,11 @@ func (i *Flow) FillFromBSONMap(inputMap bson.M) error {
 
 	packetTotalIface, ok := netflowMap["packetTotalCount"]
 	if !ok {
-		return errors.New("input map must contain key 'netflow.packetTotalCount'")
+		//delta counts CAN be total counts by RFC definition >.<"
+		packetTotalIface, ok = netflowMap["packetDeltaCount"]
+		if !ok {
+			return errors.New("input map must contain key 'netflow.packetTotalCount' or 'netflow.packetDeltaCount'")
+		}
 	}
 	//fmt.Println("25")
 	packetTotal, ok := packetTotalIface.(int64)


### PR DESCRIPTION
IPFIX-RITA should only be used with IPFIX exporters that export a single flow record per physical flow. These flows should only be exported when the physical flow has been closed or has timed out. 

Some IPFIX exporters use deltaCounters instead of totalCounters even though they are exporting
a single flow record per flow. If we assume the 1 flow record <-> 1 physical flow relation, we can 
parse deltaCounters just as we would parse totalCounters.

For example, there are the OctetDeltaCount and OctetTotalCount fields which measure the number 
of bytes sent in the flow at the IP level. 

OctetDeltaCount type:
```
3.2.3.  deltaCounter

   An integral value reporting the value of a counter.  Counters are
   unsigned and wrap back to zero after reaching the limit of the type.
   For example, an unsigned64 with counter semantics will continue to
   increment until reaching the value of 2**64 - 1.  At this point, the
   next increment will wrap its value to zero and continue counting from
   zero.  The semantics of a delta counter is similar to the semantics
   of counters used in SNMP, such as Counter32 defined in RFC 2578
   [RFC2578].  The only difference between delta counters and counters
   used in SNMP is that the delta counters have an initial value of 0.
   A delta counter is reset to 0 each time its value is exported.
```
OctetDeltaCount definition:
```
The number of octets since the previous report (if any) in incoming packets 
for this Flow at the Observation Point. The number of octets includes 
IP header(s) and IP payload.
```

OctetTotalCount type:
```
3.2.2.  totalCounter

   An integral value reporting the value of a counter.  Counters are
   unsigned and wrap back to zero after reaching the limit of the type.
   For example, an unsigned64 with counter semantics will continue to
   increment until reaching the value of 2**64 - 1.  At this point, the
   next increment will wrap its value to zero and continue counting from
   zero.  The semantics of a total counter is similar to the semantics
   of counters used in SNMP, such as Counter32 defined in RFC 2578
   [RFC2578].  The only difference between total counters and counters
   used in SNMP is that the total counters have an initial value of 0.
   A total counter counts independently of the export of its value.
```
OctetTotalCount definition:
```
The total number of octets in incoming packets for this Flow at the Observation
Point since the Metering Process (re-)initialization for this Observation Point. 
The number of octets includes IP header(s) and IP payload. 
```


