### PR TITLE
Make release fix

### DIFF
--- a/dev-scripts/make-release.sh
+++ b/dev-scripts/make-release.sh
@@ -82,7 +82,7 @@ done
 mkdir "$INSTALLER_BIN_DIR"
 # Construct the main script
 # Copy the shebang line in
-head  "$IN_DEV_MAIN_SCRIPT" >> "$INSTALLER_MAIN_SCRIPT"
+head -n 1  "$IN_DEV_MAIN_SCRIPT" >> "$INSTALLER_MAIN_SCRIPT"
 
 # Ensure the right versions of the images are ran
 echo "export IPFIX_RITA_VERSION=$IPFIX_RITA_VERSION" >> "$INSTALLER_MAIN_SCRIPT"


### PR DESCRIPTION
### Non-Critical Bug in Installer
When creating the new `ipfix-rita` script to be deployed, the `make-release` script copied several lines instead of just one when copying in the she-bang line. 

If this PR is declined, a new one will be created to address this bug. See line 85 of `make-release`. Additionally, run `vim /opt/ipfix-rita/bin/ipfix-rita` to see what was accidentally duplicated.