### PR TITLE
Change TZ variable setter to use timedatectl

### DIFF
--- a/runtime/bin/ipfix-rita
+++ b/runtime/bin/ipfix-rita
@@ -38,7 +38,7 @@ fi
 # layout as the host's then the bind mounted symlink would work.
 # However, this cannot be guaranteed.
 if [ -z "$TZ" ]; then
-  export TZ="$(basename $(dirname $(readlink /etc/localtime)))/$(basename $(readlink /etc/localtime))"
+  export TZ="$(timedatectl status | grep zone | cut -d':' -f2 | cut -d' ' -f2)"
 fi
 
 docker-compose -f "$_COMPOSE_FILE" "$@"


### PR DESCRIPTION
Some ISOs for Ubuntu 16.04 create /etc/localtime using a copied file rather than a symlink. This breaks the current command for fetching the system timezone. 

The new method uses timedatectl which is provided by systemd, so this method should work for any modern systemd based distribution.